### PR TITLE
Enter key on close button with JAWS closes modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
                         <input type="button" name="button" id="enter" value="Submit">
                         <input type="button" name="cancelButton" id="cancelButton" value="Cancel">
                     </p>
-                    <a id="modalCloseButton" class="modalCloseButton" href="javascript:void(0)" title="Close registration form"><img id="cancel" src="x.png" alt="close the registration form"></a>
+                    <a id="modalCloseButton" class="modalCloseButton" href="javascript:hideModal()" title="Close registration form"><img id="cancel" src="x.png" alt="close the registration form"></a>
 
                 </form>
             </div> <!-- Matching div for optional role="document" -->


### PR DESCRIPTION
Using JAWS14 on IE8 when hitting enter while focus is on the close button, nothing happened. This is the fix.
