### PR TITLE
Set focus to modal usage instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,9 +144,9 @@
                 </li>
             </ol>
         </div>
-        <div id="modal" aria-hidden="true" aria-labelledby="modalTitle" aria-describedby="modalDescription" role="dialog">
+        <div id="modal" aria-hidden="true" aria-labelledby="modalTitle" aria-describedby="modalUsage" role="dialog">
             <div role="document"> <!-- Optional role if you want screen reader users to be able to interact with objects other than focusable elements and their labels.  -->
-                <div id="modalDescription" class="screen-reader-offscreen">Beginning of dialog window. It begins with a heading 1 called &quot;Registration Form&quot;. Escape will cancel and close the window. This form does not collect any actual information.</div>
+                <div id="modalUsage" tabindex="-1" class="screen-reader-offscreen">Escape key will cancel and close this dialog window.</div>
                 <h1 id="modalTitle">Registration Form</h1>
                 <p>These are the onscreen instructions that are not attached explicitly to a focusable element. Can screen reader users read this text with the virtual cursor?</p>
                 <form name="form1" method="post" action="">

--- a/modal-window.js
+++ b/modal-window.js
@@ -167,14 +167,11 @@ function showModal(obj) {
     // save current focus
     focusedElementBeforeModal = jQuery(':focus');
 
-    // get list of all children elements in given object
-    var o = obj.find('*');
-
     // Safari and VoiceOver shim
     // if VoiceOver in Safari is used, set the initial focus to the modal window itself instead of the first keyboard focusable item. This causes VoiceOver to announce the aria-labelled attributes. Otherwise, Safari and VoiceOver will not announce the labels attached to the modal window.
 
-    // set the focus to the first keyboard focusable item
-    o.filter(focusableElementsString).filter(':visible').first().focus();
+    // set the focus to the modal usage instructions.
+    $('#modalUsage').focus();
 
 
 }


### PR DESCRIPTION
When the modal is displayed to the screen, the focus should be placed at the top of the modal content. Rather than first field as is does with JAWS 14.
