### PR TITLE
Additional closing modal methods

### DIFF
--- a/modal-window.js
+++ b/modal-window.js
@@ -53,6 +53,9 @@ $(document).ready(function() {
     jQuery('#startModal').click(function(e) {
         showModal($('#modal'));
     });
+    jQuery('#modalOverlay').click(function(e) {
+        hideModal();
+    });
     jQuery('#cancel').click(function(e) {
         hideModal();
     });


### PR DESCRIPTION
Adds the option to close the modal using the browser back button and by clicking off the modal itself.
